### PR TITLE
GUI: empty png bug fix

### DIFF
--- a/constrain/app/app.py
+++ b/constrain/app/app.py
@@ -23,6 +23,7 @@ from .meta_form import MetaForm
 from .workflow_diagram import WorkflowDiagram
 from .rect_connect import CustomItem
 from .submit import Worker, SubmitPopup
+from . import utils
 
 from constrain.api.workflow import Workflow
 
@@ -148,6 +149,12 @@ class GUI(QMainWindow):
 
     def exportFile(self):
         """Exports current state as a .json to local storage"""
+
+        scene = self.states_form.scene
+        if not scene.items():
+            utils.send_error("Export Error", "Workflow is empty. Add a workflow to export")
+            return
+            
         fp, _ = QFileDialog.getSaveFileName(
             self, "Save JSON File", "", "JSON Files (*.json);;All Files (*)"
         )
@@ -162,11 +169,15 @@ class GUI(QMainWindow):
 
     def exportAsPng(self):
         """Exports current state as a .png to local storage"""
+
+        scene = self.states_form.scene
+        if not scene.items():
+            utils.send_error("Export Error", "Workflow is empty. Add a workflow to export")
+            return
+            
         fp, _ = QFileDialog.getSaveFileName(self, "Save Image", "", "PNG Files (*.png)")
 
         if fp:
-            scene = self.states_form.scene
-            scene.sceneRect().size()
             pixmap = QPixmap(scene.sceneRect().size().toSize())
             pixmap.fill(QColor(255, 255, 255))
             painter = QPainter(pixmap)

--- a/constrain/app/app.py
+++ b/constrain/app/app.py
@@ -152,9 +152,11 @@ class GUI(QMainWindow):
 
         scene = self.states_form.scene
         if not scene.items():
-            utils.send_error("Export Error", "Workflow is empty. Add a workflow to export")
+            utils.send_error(
+                "Export Error", "Workflow is empty. Add a workflow to export"
+            )
             return
-            
+
         fp, _ = QFileDialog.getSaveFileName(
             self, "Save JSON File", "", "JSON Files (*.json);;All Files (*)"
         )
@@ -172,9 +174,11 @@ class GUI(QMainWindow):
 
         scene = self.states_form.scene
         if not scene.items():
-            utils.send_error("Export Error", "Workflow is empty. Add a workflow to export")
+            utils.send_error(
+                "Export Error", "Workflow is empty. Add a workflow to export"
+            )
             return
-            
+
         fp, _ = QFileDialog.getSaveFileName(self, "Save Image", "", "PNG Files (*.png)")
 
         if fp:

--- a/constrain/app/rect_connect.py
+++ b/constrain/app/rect_connect.py
@@ -9,6 +9,7 @@ import re
 
 from PyQt6 import QtCore, QtGui, QtWidgets
 
+from . import utils
 
 class Path(QtWidgets.QGraphicsPathItem):
     def __init__(self, start, p2, end=None):
@@ -241,14 +242,6 @@ class ControlPoint(QtWidgets.QGraphicsEllipseItem):
             if existing.controlPoints() == pathItem.controlPoints():
                 return False
 
-        # define error message
-        def send_error(text):
-            error_msg = QtWidgets.QMessageBox()
-            error_msg.setIcon(QtWidgets.QMessageBox.Icon.Critical)
-            error_msg.setWindowTitle("Error in Path")
-            error_msg.setText(text)
-            error_msg.exec()
-
         # only consider sending error message if self is the start of the path
         if pathItem.start == self:
             # determine if parent will have too many children states
@@ -256,8 +249,7 @@ class ControlPoint(QtWidgets.QGraphicsEllipseItem):
             if rect_children_amt >= 1:
                 if self.parent.state["Type"] != "Choice":
                     # MethodCall type CustomItem can only connect to 1 CustomItem
-                    error_msg = "This type cannot connect to more than 1 state"
-                    send_error(error_msg)
+                    utils.send_error("Error in Path", "This type cannot connect to more than 1 state")
                     return False
                 elif self.parent.state["Type"] == "Choice":
                     # Choice type CustomItem can connect to more than 1 CustomItem, but need to see how many are defined in the state
@@ -267,7 +259,7 @@ class ControlPoint(QtWidgets.QGraphicsEllipseItem):
 
                     if rect_children_amt >= choices_amt:
                         error_msg = f"This type cannot connect to more than {choices_amt} states"
-                        send_error(error_msg)
+                        utils.send_error("Error in Path", error_msg)
                         return False
             # add new child node to parent.children since path is viable
             self.parent.children.append(pathItem.end.parent)

--- a/constrain/app/rect_connect.py
+++ b/constrain/app/rect_connect.py
@@ -11,6 +11,7 @@ from PyQt6 import QtCore, QtGui, QtWidgets
 
 from . import utils
 
+
 class Path(QtWidgets.QGraphicsPathItem):
     def __init__(self, start, p2, end=None):
         """Initializes a Path from start to p2
@@ -249,7 +250,9 @@ class ControlPoint(QtWidgets.QGraphicsEllipseItem):
             if rect_children_amt >= 1:
                 if self.parent.state["Type"] != "Choice":
                     # MethodCall type CustomItem can only connect to 1 CustomItem
-                    utils.send_error("Error in Path", "This type cannot connect to more than 1 state")
+                    utils.send_error(
+                        "Error in Path", "This type cannot connect to more than 1 state"
+                    )
                     return False
                 elif self.parent.state["Type"] == "Choice":
                     # Choice type CustomItem can connect to more than 1 CustomItem, but need to see how many are defined in the state

--- a/constrain/app/utils.py
+++ b/constrain/app/utils.py
@@ -2,13 +2,13 @@ from PyQt6.QtWidgets import QMessageBox
 
 
 def send_error(window_title, text):
-        """Displays an error message with given text
+    """Displays an error message with given text
 
-        Args:
-            text (str): text to be displayed
-        """
-        error_msg = QMessageBox()
-        error_msg.setIcon(QMessageBox.Icon.Critical)
-        error_msg.setWindowTitle(window_title)
-        error_msg.setText(text)
-        error_msg.exec()
+    Args:
+        text (str): text to be displayed
+    """
+    error_msg = QMessageBox()
+    error_msg.setIcon(QMessageBox.Icon.Critical)
+    error_msg.setWindowTitle(window_title)
+    error_msg.setText(text)
+    error_msg.exec()

--- a/constrain/app/utils.py
+++ b/constrain/app/utils.py
@@ -1,0 +1,14 @@
+from PyQt6.QtWidgets import QMessageBox
+
+
+def send_error(window_title, text):
+        """Displays an error message with given text
+
+        Args:
+            text (str): text to be displayed
+        """
+        error_msg = QMessageBox()
+        error_msg.setIcon(QMessageBox.Icon.Critical)
+        error_msg.setWindowTitle(window_title)
+        error_msg.setText(text)
+        error_msg.exec()


### PR DESCRIPTION
GUI now gives an error popup when user exports an empty workflow (states scene has no items) as a png or a JSON. 