### PR TITLE
Added pre-commit-config

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,12 @@
+repos:
+  - repo: https://github.com/pre-commit/pre-commit-hooks
+    rev: v4.5.0
+    hooks:
+      - id: check-case-conflict
+      - id: check-merge-conflict
+      - id: mixed-line-ending
+      - id: trailing-whitespace
+  - repo: https://github.com/psf/black-pre-commit-mirror
+    rev: 24.1.1
+    hooks:
+    -   id: black

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,6 +25,7 @@ pydash = "^7.0.6"
 pyyaml = "^6.0.1"
 pyqt6 = "^6.6.1"
 click = "^8.1.7"
+pre-commit = "^3.6.0"
 
 
 [build-system]

--- a/setup.py
+++ b/setup.py
@@ -37,5 +37,6 @@ setup(
         "uuid",
         "pydash",
         "PyYAML",
+        "pre-commit",
     ],
 )


### PR DESCRIPTION
**Note**: must be installed with 'pre-commit install' at root of ConStrain after dependencies are installed.

Adds pre-commit config file to check for case conflict (files that would conflict in case-insensitive filesystems), and merge conflict (files that contain merge conflict strings) before commit is accepted. Fixes commits if they have mixed line-endings, trailing whitespace, and aren't in black.

In the case of a fix, failed commit will remain in staging and the updates still must be added to staging before commit.

Here's the website for more information: [https://pre-commit.com/](url)

Here's a list of hooks if we want to add more or remove any: [https://pre-commit.com/hooks.html](url)