### PR TITLE
GUI: Adds popup to check if user wants to overwrite data on import

### DIFF
--- a/constrain/app/import_form.py
+++ b/constrain/app/import_form.py
@@ -105,3 +105,14 @@ class ImportForm(QWidget):
             list: a list of the current imports
         """
         return self.imports
+
+    def contains_data(self):
+        """Check if import form contains any data"""
+        return bool(self.imports)
+
+    def clear(self):
+        """Clear import form"""
+        self.import_list.clear()
+        self.imports.clear()
+        self.import_input.clear()
+        self.update()

--- a/constrain/app/meta_form.py
+++ b/constrain/app/meta_form.py
@@ -97,3 +97,24 @@ class MetaForm(QWidget):
 
     def get_workflow_name(self):
         return self.name_input.text()
+
+    def contains_data(self):
+        """Check if meta form contains any data"""
+        return all(
+            [
+                self.name_input.text(),
+                self.author_input.text(),
+                self.date_input.text(),
+                self.version_input.text(),
+                self.description_input.toPlainText(),
+            ]
+        )
+
+    def clear(self):
+        """Clear meta form"""
+        self.name_input.clear()
+        self.author_input.clear()
+        self.date_input.clear()
+        self.version_input.clear()
+        self.description_input.clear()
+        self.update()

--- a/constrain/app/popup_window.py
+++ b/constrain/app/popup_window.py
@@ -21,7 +21,7 @@ from PyQt6.QtWidgets import (
 )
 from PyQt6.QtGui import QPixmap
 
-from .list_and_choice_popups import ListPopup, ChoicesPopup
+from constrain.app.list_and_choice_popups import ListPopup, ChoicesPopup
 
 script_directory = os.path.dirname(os.path.abspath(__file__))
 dependencies_path = os.path.join(script_directory, "dependencies.json")

--- a/constrain/app/submit.py
+++ b/constrain/app/submit.py
@@ -8,7 +8,6 @@ from PyQt6.QtWidgets import (
 )
 from PyQt6.QtCore import QThread, pyqtSignal
 
-import constrain
 from constrain.api.workflow import Workflow
 
 

--- a/constrain/app/utils.py
+++ b/constrain/app/utils.py
@@ -12,3 +12,20 @@ def send_error(window_title, text):
     error_msg.setWindowTitle(window_title)
     error_msg.setText(text)
     error_msg.exec()
+
+
+def send_are_you_sure(text):
+    """Displays an 'are you sure' message with given text
+
+    Args:
+        text (str): text to be displayed
+    """
+    msg_box = QMessageBox()
+    msg_box.setIcon(QMessageBox.Icon.Question)
+    msg_box.setText(f"Are you sure? {text}")
+    msg_box.setStandardButtons(
+        QMessageBox.StandardButton.Yes | QMessageBox.StandardButton.No
+    )
+    msg_box.setWindowTitle("ConStrain")
+    response = msg_box.exec()
+    return response

--- a/constrain/app/workflow_diagram.py
+++ b/constrain/app/workflow_diagram.py
@@ -17,9 +17,9 @@ from PyQt6.QtGui import (
     QPen,
     QBrush,
 )
-from .popup_window import PopupWindow
-from .advanced_popup import AdvancedPopup
-from .rect_connect import Scene, CustomItem, ControlPoint, Path
+from constrain.app.popup_window import PopupWindow
+from constrain.app.advanced_popup import AdvancedPopup
+from constrain.app.rect_connect import Scene, CustomItem, ControlPoint, Path
 import json
 
 
@@ -436,3 +436,13 @@ class WorkflowDiagram(QWidget):
                 new_state = states[state_name]
                 new_state["Title"] = state_name
                 self.create_item(new_state)
+
+    def contains_data(self):
+        """Check if workflow diagram contains any data"""
+        return bool(self.scene.items())
+
+    def clear(self):
+        """Clear all state"""
+        self.scene.clear()
+        self.view.resetTransform()
+        self.update()


### PR DESCRIPTION
Covers tickets 19 and 20. Doesn't directly ask about saving, but can be added.

Each view (meta, imports, states) is checked for existing data when an import is requested. If data exists, a popup is displayed asking if they want to erase current data. If the answer is yes, then data will be overwritten once an import file is selected. If the answer is no, then the popup exits and they won't be able to select an import file.

Also added __init__.py and changed how we import in the GUI since it was a little confusing.