### PR TITLE
GUI: State creation logic issue/runtime error

### DIFF
--- a/constrain/app/workflow_diagram.py
+++ b/constrain/app/workflow_diagram.py
@@ -375,23 +375,20 @@ class WorkflowDiagram(QWidget):
             rect (CustomItem): CustomItem associated with the popup needed
             edit (bool): False if creating new CustomItem, True otherwise
         """
-        if self.setting == "basic":
-            payloads = self.scene.getObjectsCreated()
-            if rect:
-                if not rect.popup or isinstance(rect.popup, AdvancedPopup):
-                    # make a new popup
-                    rect.popup = PopupWindow(
-                        payloads,
-                        state_names=self.scene.getStateNames(),
-                        rect=rect,
-                        load=True,
-                    )
-                rect.popup.edit_mode(payloads)
-                self.popup = rect.popup
-            else:
-                self.popup = PopupWindow(
-                    payloads, state_names=self.scene.getStateNames()
+        payloads = self.scene.getObjectsCreated()
+        if rect:
+            if not rect.popup or isinstance(rect.popup, AdvancedPopup):
+                # make a new popup
+                rect.popup = PopupWindow(
+                    payloads,
+                    state_names=self.scene.getStateNames(),
+                    rect=rect,
+                    load=True,
                 )
+            rect.popup.edit_mode(payloads)
+            self.popup = rect.popup
+        else:
+            self.popup = PopupWindow(payloads, state_names=self.scene.getStateNames())
 
         if edit and rect:
             try:


### PR DESCRIPTION
Fixes problem where creating basic state after deleting all state will provide a pop-up window (28), and when trying to create a Basic State with Advanced State settings would crash the app.

Removes single line that checks if Basic Popup settings are active. Check should not be there at all since logic should be the same either way.