### PR TITLE
GUI: Allows Deletion of Multiple States

### DIFF
--- a/constrain/app/rect_connect.py
+++ b/constrain/app/rect_connect.py
@@ -3,6 +3,7 @@ This file contains the classes Path, ControlPoint, CustomItem, and Scene. These 
 CustomItem contains the state, Path links 2 ControlPoints with an arrowed line, ControlPoints are on the edges of CustomItems, and Scene contains
 all of this.
 """
+
 import json
 import math
 import re
@@ -434,28 +435,31 @@ class CustomItem(QtWidgets.QGraphicsItem):
         action = menu.exec(event.screenPos())
 
         if action == delete_action:
+            self.delete()
             # find payloads that self.state has created
-            objects_created = self.get_objects_created()
 
-            # find what objects are currently being used by other states
-            all_objects_in_use = self.scene().getObjectsinUse()
+    def delete(self):
+        objects_created = self.get_objects_created()
 
-            # make sure that payloads from self.state are not being used by another state
-            for created_object in objects_created:
-                if created_object in all_objects_in_use:
-                    self.sendError("Object created in use")
-                    return
+        # find what objects are currently being used by other states
+        all_objects_in_use = self.scene().getObjectsinUse()
 
-            # remove lines
-            for c in self.controls:
-                for p in c.paths:
-                    p1 = p.start
-                    p2 = p.end
-                    if p1 in self.controls:
-                        p2.removeLine(p)
-                    else:
-                        p1.removeLine(p)
-            self.scene().removeItem(self)
+        # make sure that payloads from self.state are not being used by another state
+        for created_object in objects_created:
+            if created_object in all_objects_in_use:
+                self.sendError("Object created in use")
+                return
+
+        # remove lines
+        for c in self.controls:
+            for p in c.paths:
+                p1 = p.start
+                p2 = p.end
+                if p1 in self.controls:
+                    p2.removeLine(p)
+                else:
+                    p1.removeLine(p)
+        self.scene().removeItem(self)
 
     def sendError(self, text):
         """Displays an error message given text

--- a/constrain/app/workflow_diagram.py
+++ b/constrain/app/workflow_diagram.py
@@ -6,6 +6,7 @@ from PyQt6.QtWidgets import (
     QGraphicsView,
     QGraphicsTextItem,
     QGraphicsRectItem,
+    QMenu,
 )
 from PyQt6.QtCore import Qt, pyqtSignal, QRectF
 from PyQt6.QtGui import (
@@ -16,11 +17,14 @@ from PyQt6.QtGui import (
     QColor,
     QPen,
     QBrush,
+    QAction,
 )
 from constrain.app.popup_window import PopupWindow
 from constrain.app.advanced_popup import AdvancedPopup
 from constrain.app.rect_connect import Scene, CustomItem, ControlPoint, Path
+from constrain.app.utils import send_error
 import json
+from collections import Counter
 
 
 class Zoom(QGraphicsView):
@@ -71,6 +75,54 @@ class Zoom(QGraphicsView):
             event.accept()
         else:
             super().keyPressEvent(event)
+
+    def contextMenuEvent(self, event):
+        menu = QMenu(self)
+
+        # Check if there's an item under the mouse cursor
+        selected_states = [
+            item
+            for item in self.scene.items()
+            if item.isSelected() and isinstance(item, CustomItem)
+        ]
+        if selected_states:
+            delete_action = QAction("Delete", self)
+            delete_action.triggered.connect(lambda: self.delete_items(selected_states))
+            menu.addAction(delete_action)
+        else:
+            item = self.itemAt(event.pos())
+
+            if isinstance(item, CustomItem):
+                delete_action = QAction("Delete", self)
+                delete_action.triggered.connect(item.delete)
+                menu.addAction(delete_action)
+
+        menu.exec(event.globalPos())
+
+    def delete_items(self, item_list):
+        all_objects_in_use = Counter(self.scene.getObjectsinUse())
+        objects_used_in_items = Counter(
+            [
+                item_object
+                for item in item_list
+                for item_object in item.get_objects_used()
+            ]
+        )
+        objects_not_used_in_items = set(all_objects_in_use - objects_used_in_items)
+        objects_created_in_items = set()
+        for item in item_list:
+            objects_created_in_items |= set(item.get_objects_created())
+
+        intersection = objects_created_in_items & objects_not_used_in_items
+        if intersection:
+            error_msg = f"{", ".join(intersection)} being used by other state"
+            if len(intersection) > 1:
+                error_msg += "s"
+            send_error("Error deleting state", error_msg)
+            return
+
+        for item in item_list:
+            item.delete()
 
     def mouseDoubleClickEvent(self, event):
         super().mouseDoubleClickEvent(event)

--- a/constrain/app/workflow_diagram.py
+++ b/constrain/app/workflow_diagram.py
@@ -194,7 +194,6 @@ class Zoom(QGraphicsView):
                 if isinstance(item, CustomItem) and rect.intersects(
                     item.mapRectToScene(item.rect)
                 ):
-                    print(item.state["Title"])
                     selected_items.append(item)
                     item.setSelected(True)
 

--- a/constrain/app/workflow_diagram.py
+++ b/constrain/app/workflow_diagram.py
@@ -115,7 +115,8 @@ class Zoom(QGraphicsView):
 
         intersection = objects_created_in_items & objects_not_used_in_items
         if intersection:
-            error_msg = f"{", ".join(intersection)} being used by other state"
+            error_msg_object = ", ".join(intersection)
+            error_msg = f"{error_msg_object} being used by other state"
             if len(intersection) > 1:
                 error_msg += "s"
             send_error("Error deleting state", error_msg)
@@ -494,3 +495,4 @@ class WorkflowDiagram(QWidget):
         self.scene.clear()
         self.view.resetTransform()
         self.update()
+        self.popup = None


### PR DESCRIPTION
This PR adds the functionality of being able to move and delete multiple states that are selected. States are selected by clicking and dragging a rectangle around them or ctrl+click. Like with the deletion of a single state that we have currently, an error will be raised if any of the selected states create objects that are being used in other states.