### PR TITLE
Update dependencies

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,6 +26,7 @@ pyyaml = "^6.0.1"
 pyqt6 = "^6.6.1"
 click = "^8.1.7"
 pre-commit = "^3.6.0"
+python-levenshtein = "^0.25.1"
 
 
 [build-system]


### PR DESCRIPTION
Add `python-levenshtein` to the dependencies to avoid regular warnings.
```
/home/runner/.local/lib/python3.10/site-packages/fuzzywuzzy/fuzz.py:11: UserWarning: Using slow pure-python SequenceMatcher. Install python-Levenshtein to remove this warning
  warnings.warn('Using slow pure-python SequenceMatcher. Install python-Levenshtein to remove this warning')
```