### PR TITLE
Fix boolean value plotting

### DIFF
--- a/constrain/checklib.py
+++ b/constrain/checklib.py
@@ -213,6 +213,9 @@ class CheckLibBase(ABC):
                 if pt_nan[pt]:
                     self.df[pt].plot(ax=axx, marker=".")
                 else:
+                    # check if values in the series are boolean
+                    if self.df[pt].apply(lambda x: isinstance(x, bool)).all():
+                        self.df[pt] = self.df[pt].astype(int)
                     self.df[pt].plot(ax=axx)
                 plt.title(f"All samples - {pt} - {self.__class__.__name__}")
                 i += 1
@@ -326,6 +329,9 @@ class CheckLibBase(ABC):
                 if pt_nan[pt]:
                     plotdaydf[pt].plot(ax=axx, marker=".")
                 else:
+                    # check if values in the series are boolean
+                    if self.df[pt].apply(lambda x: isinstance(x, bool)).all():
+                        self.df[pt] = self.df[pt].astype(int)
                     plotdaydf[pt].plot(ax=axx)
                 plt.title(f"Example day - {pt} - {self.__class__.__name__}")
                 i += 1


### PR DESCRIPTION
When plotting a boolean type value, I found that it can't be plotted because it's not a numeric value. And, this message, ```print(f"{pt} cannot be plotted by itself, ignored in the plot.")```, is printed out. However, I believe boolean value can/should be plotted (False -> 0, True -> 1).

What do you think? If this code is not useful, please kindly close this PR! Thank you!