### PR TITLE
Create development dependency group

### DIFF
--- a/.github/workflows/test_deployment.yml
+++ b/.github/workflows/test_deployment.yml
@@ -28,7 +28,7 @@ jobs:
                 path: ./.venv
                 key: venv-${{ hashFiles('poetry.lock') }}
             - name: Install the project dependencies
-              run: poetry install
+              run: poetry install --with dev
             - name: Build package
               run: poetry build
             - name: Install package

--- a/.github/workflows/unit_tests.yml
+++ b/.github/workflows/unit_tests.yml
@@ -37,6 +37,6 @@ jobs:
           path: ./.venv
           key: venv-${{ hashFiles('poetry.lock') }}
       - name: Install the project dependencies
-        run: poetry install
+        run: poetry install -- with dev
       - name: Run the tests
         run: poetry run pytest -v

--- a/.github/workflows/unit_tests.yml
+++ b/.github/workflows/unit_tests.yml
@@ -37,6 +37,6 @@ jobs:
           path: ./.venv
           key: venv-${{ hashFiles('poetry.lock') }}
       - name: Install the project dependencies
-        run: poetry install -- with dev
+        run: poetry install --with dev
       - name: Run the tests
         run: poetry run pytest -v

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,6 +8,9 @@ readme = "README.md"
 [tool.poetry.scripts]
 constrain = "constrain.cli:cli"
 
+[tool.poetry.group.dev]
+optional = true
+
 [tool.poetry.dependencies]
 python = "^3.10"
 matplotlib = "^3.8.2"
@@ -19,15 +22,16 @@ scikit-learn = "^1.3.2"
 scipy = "^1.11.4"
 tqdm = "^4.66.1"
 uuid = "^1.30"
-pytest = "^7.4.3"
 brickschema = "0.7.1"
 pydash = "^7.0.6"
 pyyaml = "^6.0.1"
 pyqt6 = "^6.6.1"
 click = "^8.1.7"
-pre-commit = "^3.6.0"
 jsonschema= "^4.21.1"
-#python-levenshtein = "^0.25.1"
+
+[tool.poetry.group.dev.dependencies]
+pre-commit = "^3.6.0"
+pytest = "^7.4.3"
 black = "24.3.0"
 
 [build-system]


### PR DESCRIPTION
Address a comment from #88.

This PR creates dependency groups, the `dev` group being optional and only used for development purpose.

- `poetry install` doesn't install the dependencies in the `dev` group.
- `poetry install --with dev` install all dependencies
