### PR TITLE
Dynamically calculate histogram bins for SAT reset verification

### DIFF
--- a/constrain/library/supply_air_temp_reset.py
+++ b/constrain/library/supply_air_temp_reset.py
@@ -58,6 +58,7 @@ else:
 from datetime import date
 
 import matplotlib.pyplot as plt
+import numpy as np
 import seaborn as sns
 from constrain.checklib import RuleCheckBase
 
@@ -76,12 +77,44 @@ class SupplyAirTempReset(RuleCheckBase):
             self.df["temperature_air_zone_design_cool_setpoint"] - t_sa_set_min
         ) * 0.25 * (1 - self.get_tolerance("ratio", "temperature") * 1)
 
+    def fd_bins(self, data, min_bins=5, max_bins=100):
+        data = np.asarray(data)
+        data = data[~np.isnan(data)]
+        if data.size < 2:
+            return 1
+
+        q25, q75 = np.percentile(data, [25, 75])
+        iqr = q75 - q25
+        if iqr == 0:
+            # fall back to std or Sturges
+            std = data.std(ddof=1)
+            if std == 0:
+                return 1
+            bin_width = 3.5 * std / (data.size ** (1 / 3))
+        else:
+            bin_width = 2 * iqr / (data.size ** (1 / 3))
+
+        data_range = data.max() - data.min()
+        if bin_width <= 0 or data_range == 0:
+            return 1
+
+        n_bins = int(np.ceil(data_range / bin_width))
+        n_bins = max(min_bins, n_bins)
+        n_bins = min(max_bins, n_bins)
+        return n_bins
+
     def plot(self, plot_option, fig_size=(6.4, 4.8), plt_pts=None):
         print(
             "Specific plot method implemented, additional distribution plot is being added!"
         )
-        sns.histplot(self.df["temperature_air_supply_setpoint"])
-        plt.title("All samples distribution of temperature_air_supply")
+        sns.histplot(
+            self.df["temperature_air_supply_setpoint"],
+            bins=self.fd_bins(self.df["temperature_air_supply_setpoint"]),
+            stat="count",
+        )
+        plt.title("Distribution of Supply Air Temperature Setpoint")
+        plt.xlabel("Temperature")
+        plt.ylabel("Count")
         plt.savefig(
             f"{self.results_folder}/All_samples_distribution_of_temperature_air_supply.png"
         )


### PR DESCRIPTION
The code relies on the Freedman-Diaconis rule: https://en.wikipedia.org/wiki/Freedman%E2%80%93Diaconis_rule

Using the LBNL59 data ([here](https://bbd.labworks.org/ds/bbd/lbnlbldg59)) and the verification case file from [here](https://github.com/pnnl/ANIMATE/blob/rl_bldg_data_test/test_cases/lbnl59_cases/lbnl59_cases.json) we got from this using the current code:

<img width="468" height="351" alt="image" src="https://github.com/user-attachments/assets/8b0e9bfe-ce9e-4f70-8dec-2dbfdcad2272" />

To the following with the new proposed code:

<img width="632" height="473" alt="image" src="https://github.com/user-attachments/assets/3c4f6610-d093-4ef9-b022-249dbdfee46b" />
